### PR TITLE
Fix: font not updating on Android

### DIFF
--- a/Uniforms.Misc.Droid/Utils/TextUtils.cs
+++ b/Uniforms.Misc.Droid/Utils/TextUtils.cs
@@ -15,6 +15,8 @@ namespace Uniforms.Misc.Droid
 
         static Typeface textTypeface;
 
+        static string createdFontName;
+
         public Xamarin.Forms.Size GetTextSize (
             string text,
             double maxWidth,
@@ -45,8 +47,9 @@ namespace Uniforms.Misc.Droid
                 return Typeface.Default;
             }
 
-            if (textTypeface == null) {
+            if (textTypeface == null || fontName != createdFontName) {
                 textTypeface = Typeface.Create (fontName, TypefaceStyle.Normal);
+                createdFontName = fontName;
             }
 
             return textTypeface;


### PR DESCRIPTION
Previously on Android, calling GetTextSize twice with two different fonts would reuse the first font in the second call

This change should cause the font name to be used for each call to GetTextSize

I haven't yet managed to build this project and verify this change (it seems that it might require updating Xamarin), would it help if I did that?